### PR TITLE
Bugfix: Update hashable package

### DIFF
--- a/fmdtools/modeldef.py
+++ b/fmdtools/modeldef.py
@@ -24,8 +24,7 @@ import sys
 from decimal import Decimal
 from ordered_set import OrderedSet
 from operator import itemgetter, attrgetter
-from collections.abc import Iterable
-from typing import Hashable
+from collections.abc import Iterable, Hashable
 from inspect import signature
 import fmdtools.resultdisp.process as proc
 

--- a/fmdtools/modeldef.py
+++ b/fmdtools/modeldef.py
@@ -25,7 +25,7 @@ from decimal import Decimal
 from ordered_set import OrderedSet
 from operator import itemgetter, attrgetter
 from collections.abc import Iterable
-from collections import Hashable
+from typing import Hashable
 from inspect import signature
 import fmdtools.resultdisp.process as proc
 


### PR DESCRIPTION
Minor bug- Hashable is used in input validation in modeled.py. At the top of the file it is imported from collections, but Hashable is actually in typing.